### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,20 @@
 
 Provides the [SPX](https://github.com/NoiseByNorthwest/php-spx) extension for PHP.
 
-- Run `ddev get fullfatthings/ddev-spx`
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get fullfatthings/ddev-spx
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get fullfatthings/ddev-spx
+```
+
+After installation:
+
 - Run `ddev restart` - this should install the addons into php
 - To enable, run `ddev spx on` and to disable run `ddev spx off`.
 - Once enabled, browse to `https://example.ddev.site/?SPX_KEY=dev&SPX_UI_URI=/`


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.