### PR TITLE
Remove pre_install_actions with `ddev debug capabilities` and add version constraint

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,11 +1,5 @@
 name: spx
-
-pre_install_actions:
-# Make sure we have a ddev version that can support what we do here
-- |
-  #ddev-nodisplay
-  #ddev-description:Checking DDEV version
-  (ddev debug capabilities | grep ddev-get-yaml-interpolation >/dev/null) || (echo "Please upgrade DDEV to v1.21.4+ for appropriate capabilities" && false)
+ddev_version_constraint: '>v1.21.4'
 
 # List of files and directories listed that are copied into project .ddev directory.
 project_files:


### PR DESCRIPTION
`ddev debug capabilities` has been removed in upcoming v1.25.0.